### PR TITLE
Fix error - Block can´t be duplicated

### DIFF
--- a/scratch-vm/src/extensions/scratch3_onegpioArduino/index.js
+++ b/scratch-vm/src/extensions/scratch3_onegpioArduino/index.js
@@ -361,7 +361,7 @@ class Scratch3ArduinoOneGPIO {
                 },
                 on_off: {
                     acceptReporters: true,
-                    items: [{text: "0", value: 0}, {text: "1", value: 1}]
+                    items: ['0', '1']
                 }
             }
         };

--- a/scratch-vm/src/extensions/scratch3_onegpioEsp/index.js
+++ b/scratch-vm/src/extensions/scratch3_onegpioEsp/index.js
@@ -369,7 +369,7 @@ class Scratch3EspOneGPIO {
                 },
                 on_off: {
                     acceptReporters: true,
-                    items: [{text: "0", value: 0}, {text: "1", value: 1}]
+                    items: ['0', '1']
                 }
             }
         };

--- a/scratch-vm/src/extensions/scratch3_onegpioRpi/index.js
+++ b/scratch-vm/src/extensions/scratch3_onegpioRpi/index.js
@@ -362,7 +362,7 @@ class Scratch3RpiOneGPIO {
 
                 on_off: {
                     acceptReporters: true,
-                    items: [{text: "0", value: 0}, {text: "1", value: 1}]
+                    items: ['0', '1']
                 }
             }
         };


### PR DESCRIPTION
When select Write digital Pin which value = 1, block not allowed to be duplicated.

Description of Error:
Uncaught TypeError: Failed to execute 'appendChild' on 'Node': parameter 1 is not of type 'Node'.